### PR TITLE
Fixed typo in README.md locations example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ require 'vendor/autoload.php';
 
 # setup authorization
 \SquareConnect\Configuration::getDefaultConfiguration()->setAccessToken($access_token);
-# create an instance of the Location API $locations_api = new \SquareConnect\Api\LocationsApi();
+# create an instance of the Location API
+$locations_api = new \SquareConnect\Api\LocationsApi();
 
 try {
   $locations = $locations_api->listLocations();


### PR DESCRIPTION
- added new line so that the $locations_api variable gets set